### PR TITLE
Enable/Disable comments on Posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -96,12 +96,14 @@ post_class: post-template
 
 <!-- Begin Comments
 ================================================== -->
-<div class="container">
-    <div id="comments" class="row justify-content-center mb-5">
-        <div class="col-md-8">              
-            {% include disqus.html %}                
+{% if page.comments == true %}
+    <div class="container">
+        <div id="comments" class="row justify-content-center mb-5">
+            <div class="col-md-8">              
+                {% include disqus.html %}                
+            </div>
         </div>
     </div>
-</div>
+{% endif %}
 <!--End Comments
 ================================================== -->


### PR DESCRIPTION
### This is a tiny change on the posts layout to make comments optional, the same way as pages work. 

I found it useful for blog post where we do not want to generate too much noise: in my case I'm a developer and most of the time when I write a post and reference a repo on Github, I prefer the discussions to be there. 

Usage:

YAML Post Example:
<pre>
---
layout: post
title:  "Architecting Android... Reloaded"
author: fernando
categories: [ android, development, mobile, engineering ]
image: assets/images/architecting_android_reloaded.jpg
featured: true
comments: true
---
</pre>

Feel free to avoid this change if it is not part of the use cases of the template. 

By the way, **THANK YOU** and **GREAT JOB!**

I'm using it and have customized it a bit in order to fulfill my needs.