### PR TITLE
Remove undefined Ruby placeholder in Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ _site
 .DS_Store
 *.swp
 .sass-cache
-
+*~

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby RUBY_VERSION
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the


### PR DESCRIPTION
This is in reference to issue https://github.com/wowthemesnet/mediumish-theme-jekyll/issues/46

Also has a line for `.gitignore` that ignores backed up (`~`) files.