### PR TITLE
removed google plus sharing

### DIFF
--- a/_includes/share.html
+++ b/_includes/share.html
@@ -15,12 +15,6 @@
         </a>
         </li>
         
-        <li class="ml-1 mr-1">
-        <a target="_blank" href="https://plus.google.com/share?url={{ page.url | absolute_url }}" onclick="window.open(this.href, 'facebook-google', 'width=550,height=435');return false;">
-        <i class="fab fa-google"></i>
-        </a>
-        </li>
-        
     </ul>
     {% if page.comments != false %}
     <div class="sep">


### PR DESCRIPTION
as google plus is being shut down, there is no need to have the option to share it to g+ anymore