### PR TITLE
removed .html line endings for categories and tags

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -78,7 +78,7 @@ post_class: post-template
                     {% assign sortedCategories = page.categories | sort %}
                     {% for category in sortedCategories %}
                     <li>                        
-                     <a class="smoothscroll" href="{{site.baseurl}}/categories.html#{{ category | replace: " ","-" }}">{{ category }}</a>
+                     <a class="smoothscroll" href="{{site.baseurl}}/categories#{{ category | replace: " ","-" }}">{{ category }}</a>
                     </li>
                     {% endfor %}
 				</ul>
@@ -91,7 +91,7 @@ post_class: post-template
                     {% assign sortedTags = page.tags | sort %}
                     {% for tag in sortedTags %}
                     <li>                        
-                     <a class="smoothscroll" href="{{site.baseurl}}/tags.html#{{ tag | replace: " ","-" }}">#{{ tag }}</a>
+                     <a class="smoothscroll" href="{{site.baseurl}}/tags#{{ tag | replace: " ","-" }}">#{{ tag }}</a>
                     </li>
                     {% endfor %}
 				</ul>


### PR DESCRIPTION
These line endings are not needed, and make the site look a lot cleaner if they are not there.