### PR TITLE
Align featured image in centre

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -46,9 +46,9 @@ post_class: post-template
             {% endif %}
             <!-- End Adsense -->
 
-			<!-- Post Featured Image -->
-			{% if page.image %}<img class="featured-image img-fluid" src="{% if page.image contains "://" %}{{ page.image }}{% else %}{{ page.image | absolute_url }}{% endif %}" alt="{{ page.title }}">{% endif %}
-            <!-- End Featured Image -->
+	<!-- Post Featured Image -->
+	{% if page.image %}<div align="center"><img class="featured-image img-fluid" src="{% if page.image contains "://" %}{{ page.image }}{% else %}{{ page.image | absolute_url }}{% endif %}" alt="{{ page.title }}">{% endif %}</div>
+	<!-- End Featured Image -->
             
             <!-- Toc if any -->
             {% if page.toc %}


### PR DESCRIPTION
If the featured image is small, it is off centred in posts. This fixes that.

Just a side note, [HTML div align](https://www.w3schools.com/tags/att_div_align.asp) is outdated, so there should be a better way. However, `div align` still is supported so it works well.

You can view it in action here: https://takanodan.net/2019/03/shield-hero-11/

> (`patch-1` May error locally if you haven't deleted the branch on your local machine)