### PR TITLE
added deferring of fonts and css

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,10 +12,6 @@
     
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
-    
-<link href="https://fonts.googleapis.com/css?family=Righteous%7CMerriweather:300,300i,400,400i,700,700i" rel="stylesheet">
-    
 <link href="{{ site.baseurl }}/assets/css/screen.css" rel="stylesheet">
     
 <link href="{{ site.baseurl }}/assets/css/main.css" rel="stylesheet">
@@ -38,6 +34,11 @@ ga('send', 'pageview');
     
 {% capture layout %}{% if page.layout %}layout-{{ page.layout }}{% endif %}{% endcapture %}
 <body class="{{layout}}">
+	<!-- defer loading of font and font awesome -->
+	<noscript id="deferred-styles">
+		<link href="https://fonts.googleapis.com/css?family=Righteous%7CMerriweather:300,300i,400,400i,700,700i" rel="stylesheet">
+		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
+	</noscript>
 
     
 <!-- Begin Menu Navigation

--- a/assets/js/mediumish.js
+++ b/assets/js/mediumish.js
@@ -112,3 +112,18 @@ jQuery(document).ready(function($){
      });
     
  });   
+
+// deferred style loading
+var loadDeferredStyles = function () {
+	var addStylesNode = document.getElementById("deferred-styles");
+	var replacement = document.createElement("div");
+	replacement.innerHTML = addStylesNode.textContent;
+	document.body.appendChild(replacement);
+	addStylesNode.parentElement.removeChild(addStylesNode);
+};
+var raf = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
+	window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
+if (raf) raf(function () {
+	window.setTimeout(loadDeferredStyles, 0);
+});
+else window.addEventListener('load', loadDeferredStyles);


### PR DESCRIPTION
Dramatic improvement in site rendering, and easily editable so the user can simply place CSS they want to defer into the `div`.

I have deferred the non-crucial files of Font Awesome and text.

JS is running off the existing mediumish file to prevent too many scripts that could slow down the site. 

I have been running this on my site https://takanodan.net for a few weeks now, and have saved around 1 second in load time on slower connections (according to Pagespeed Insights and GTMetrix).

Thanks for the awesome theme and support!