### PR TITLE
Add css to html tables

### DIFF
--- a/_posts/2018-06-12-powerful-things-markdown-editor.md
+++ b/_posts/2018-06-12-powerful-things-markdown-editor.md
@@ -20,7 +20,7 @@ As well as bold and italics, you can also use some other special formatting in M
 
 ## Tables
 
-|house    |leader            |seat         |
+|House    |Leader            |Seat         |
 |---------|------------------|-------------|
 |Stark    |Jon Snow          |Winterfell   |
 |Lannister|Cersei Lannister  |Kings Landing|

--- a/_posts/2018-06-12-powerful-things-markdown-editor.md
+++ b/_posts/2018-06-12-powerful-things-markdown-editor.md
@@ -18,6 +18,14 @@ As well as bold and italics, you can also use some other special formatting in M
 + ==highlight==
 + \*escaped characters\*
 
+## Tables
+
+|house    |leader            |seat         |
+|---------|------------------|-------------|
+|Stark    |Jon Snow          |Winterfell   |
+|Lannister|Cersei Lannister  |Kings Landing|
+|Targaryen|Daenerys Targaryen|Dragonstone  |
+|Greyjoy  |Pyke              |Euron Greyjoy|
 
 ## Writing code blocks
 

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -911,6 +911,10 @@ thead {
     border-bottom: 2px solid rgba(0, 0, 0, .44);
 }
 
+td, th{
+    padding-left:8px;
+}
+
 tr:nth-of-type(2n){
     background-color: rgba(0,0,0, 0.03);
 }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -899,3 +899,18 @@ iframe {
     opacity: 0;
     transition: opacity .25s;
 }
+
+/** Minimal CSS for tables **/
+table {
+    width: 100%;
+    margin-bottom: 1.5rem;
+    line-height: 2.5;
+}
+
+thead {
+    border-bottom: 2px solid rgba(0, 0, 0, .44);
+}
+
+tr:nth-of-type(2n){
+    background-color: rgba(0,0,0, 0.03);
+}


### PR DESCRIPTION
**What**: This pull request will add some base CSS to screen.css, in order to make HTML tables usable. A screenshot of the result has been added below

**Why**: Currently tables are not really usable. A screenshot of the current state has been included below.

**Alternative**: The bootstrap table could be used as well. In this case [the `table` class needs to be added to generated table elements](https://gist.github.com/tamouse/4204dddabb6b072b0242). When this is the preferred way to go, this PR can either be adjusted or be closed without a merge. 

Feel free to edit the style to make it look better.

### Screenshots

Current situation:
![mediumish-current](https://user-images.githubusercontent.com/1094793/59337009-f23ace00-8cff-11e9-8b13-31b27ec23d7e.png)

After applying the pull request:
![mediumish-pr](https://user-images.githubusercontent.com/1094793/59337010-f23ace00-8cff-11e9-8bca-1e5f62d23250.png)

Alternative to this pull request, adding a table class to the table element:
![mediumish-bootstrap](https://user-images.githubusercontent.com/1094793/59337011-f23ace00-8cff-11e9-9b02-1c1b9720e18e.png)