### PR TITLE
FIX: pages permalinks, add trailing slash

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Mediumish Template for Jekyll
-permalink: /about
+permalink: /about/
 comments: true
 ---
 

--- a/_pages/categories.md
+++ b/_pages/categories.md
@@ -1,5 +1,5 @@
 ---
 layout: categories
 title: Categories
-permalink: /categories
+permalink: /categories/
 ---

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -1,5 +1,5 @@
 ---
 layout: tags
 title: Tags
-permalink: /tags
+permalink: /tags/
 ---

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Mediumish Jekyll Theme - Change Log
 
+## unreleased
+- FIX: permalinks in pages tags, categories, and about (in jekyll 4.x, permalinks without trailing slash has .html appended)
+
 ## 2019-05-16, v1.0.36
 - docker-composer.yml
 - better responsiveness for 1920x1080 resolution


### PR DESCRIPTION
In jekyll 4.x, permalinks without trailing slashes (eg. /tags) will automatically have .html appended (e.g. /tags.html). This breaks the tags mechanic (post links point to /tags#tag-name).