### PR TITLE
Added "vendor" (without) quotation marks to ./_config.yml file for th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,15 @@ Copyright (C) 2019 Sal, https://www.wowthemes.net
 3. Create a branch off of master and give it a meaningful name (e.g. my-new-mediumish-feature).
 4. Make necessary changes, commit, push and open a pull request on GitHub.
 
+### Usage
+
+1. [Fork the repo](https://github.com/wowthemesnet/mediumish-theme-jekyll). or do `git clone git@github.com:wowthemesnet/mediumish-theme-jekyll.git` in your directory.
+2. Change directory with the command: enter `cd mediumish-theme-jekyll/` in the terminal to change directory.
+3. Enter `bundle config set --local path 'vendor/bundle'`  in the terminal for allowing to install and update your gems.
+4. Enter `bundle install` in the terminal for installing the dependencies specified in your Gemfile.
+5. Enter `bundle update` in the terminal to update your gems to the latest available versions.
+6. Enter `bundle exec jekyll serve --livereload` in the terminal To view your static-website (--livereload to automatically reload the page, when you're changing the content inside your directory.)
+
+Check the pages in your `mediumish-theme-jekyll` for help. Example: view `2018-01-11-quick-start-guide.md` in the `_posts/2018-01-11-quick-start-guide.md` directory.
+
 Thank you!

--- a/_config.yml
+++ b/_config.yml
@@ -2,12 +2,12 @@
 name: "Mediumish"
 title: "Mediumish"
 description: "Jekyll template, Medium styled, free for bloggers."
-logo: 'assets/images/logo.png'
-favicon: 'assets/images/logo.png'
+logo: "assets/images/logo.png"
+favicon: "assets/images/logo.png"
 baseurl: /mediumish-theme-jekyll
-google_analytics: 'UA-46278016-1'
-disqus: 'demowebsite'
-mailchimp-list: 'https://wowthemes.us11.list-manage.com/subscribe/post?u=8aeb20a530e124561927d3bd8&amp;id=8c3d2d214b'
+google_analytics: "UA-46278016-1"
+disqus: "demowebsite"
+mailchimp-list: "https://wowthemes.us11.list-manage.com/subscribe/post?u=8aeb20a530e124561927d3bd8&amp;id=8c3d2d214b"
 include: ["_pages"]
 permalink: /:title/
 
@@ -23,8 +23,8 @@ authors:
     description: "Author of Mediumish, a Bootstrap Medium styled template available for WordPress, HTML, Ghost and Jekyll. You are currently previewing Jekyll template demo."
   john:
     name: John
-    display_name: John    
-    avatar: 'assets/images/avatar.png'
+    display_name: John
+    avatar: "assets/images/avatar.png"
     gravatar: b1cc14991db7a456fcd761680bbc8f81
     email: wowthemesnet@gmail.com
     web: https://www.wowthemes.net
@@ -38,19 +38,19 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-archives
-    
+
 # Archives
 jekyll-archives:
   enabled:
     - categories
   layout: archive
   permalinks:
-    category: '/category/:name/'
-    
-# Pagination 
+    category: "/category/:name/"
+
+# Pagination
 paginate: 6
 paginate_path: /page:num/
-    
+
 # Other
 markdown: kramdown
 
@@ -69,4 +69,4 @@ adsense-data-ad-slot: "1363087678"
 # Lazy Images ("enabled" or "disabled")
 lazyimages: "disabled"
 
-exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock]
+exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock, vendor]


### PR DESCRIPTION
Added "vendor" (without) quotation marks to ./_config.yml file for the build error "0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.

After this fix, it will work properly.

![Screenshot from 2022-02-09 17-52-10](https://user-images.githubusercontent.com/43880437/153257127-104dd0ad-822a-4925-9b39-6871688cd9d4.png)
"