### PR TITLE
Set up Google tag for new Google Analytics 4 support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: "Jekyll template, Medium styled, free for bloggers."
 logo: 'assets/images/logo.png'
 favicon: 'assets/images/logo.png'
 baseurl: /mediumish-theme-jekyll
-google_analytics: 'UA-46278016-1'
+google_analytics: 'G-0000000000'
 disqus: 'demowebsite'
 mailchimp-list: 'https://wowthemes.us11.list-manage.com/subscribe/post?u=8aeb20a530e124561927d3bd8&amp;id=8c3d2d214b'
 include: ["_pages"]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,13 +22,12 @@
 
 {% if jekyll.environment == 'production' %}
 <!-- change your GA id in _config.yml -->
-<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-ga('create', '{{site.google_analytics}}', 'auto');
-ga('send', 'pageview');
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.google_analytics}}"></script> 
+<script> 
+  window.dataLayer = window.dataLayer || []; 
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{site.google_analytics}}'); 
 </script>
 {% endif %}
 


### PR DESCRIPTION
Google Universal Analytics is migrated to Google Analytics 4.
https://support.google.com/analytics/answer/11583528?hl=en

The new script sets up the Google tag with Google Analytics 4 support.

See issue #175.